### PR TITLE
Include win32 in toolbar background overrides

### DIFF
--- a/styles/components/_toolbar.less
+++ b/styles/components/_toolbar.less
@@ -54,7 +54,9 @@
 }
 
 body.platform-linux,
-body.platform-linux.is-blurred {
+body.platform-linux.is-blurred,
+body.platform-win32,
+body.platform-win32.is-blurred {
   & .sheet-toolbar-container {
     background: @header;
   }


### PR DESCRIPTION
Resolves https://github.com/jakubzet/mailspring-matcha-theme/issues/5 based on the fix provided by @Vaniom

Tested and working on Windows 10 (22H2) & BunsenLabs GNU/Linux 11 (Beryllium)